### PR TITLE
Fix Consul-template install

### DIFF
--- a/consul/Dockerfile
+++ b/consul/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && \
 
 # Install S6 Overlay and Consul Template
 RUN curl -Ls https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-amd64.tar.gz | tar -xz -C / && \
-    curl -Ls https://github.com/hashicorp/consul-template/releases/download/v${CONSUL_TEMPLATE_VERSION}/consul_template_${CONSUL_TEMPLATE_VERSION}_linux_amd64.zip -o consul-template.zip && unzip consul-template.zip -d /usr/local/bin && \
+    curl -Ls https://releases.hashicorp.com/consul-template/${CONSUL_TEMPLATE_VERSION}/consul-template_${CONSUL_TEMPLATE_VERSION}_linux_amd64.zip -o consul-template.zip && unzip consul-template.zip -d /usr/local/bin && \
     rm -f consul-template* && \
     echo -ne "- with `consul-template -v 2>&1`\n" >> /root/.built
 


### PR DESCRIPTION
Hashicorp recently changed their artifacts urls, hence the Consul-template install url was broken.
This PR fixes the url composition to fetch the consul-template install from the new correct URL.
