### PR TITLE
Create stable branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # Nginx image with Consul Template
 #
-FROM nginx:1.11
+FROM nginx:1.13
 MAINTAINER 1science Devops Team <devops@1science.org>
 
 RUN apt-get update && apt-get install -y curl unzip less vim

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 #
 # Nginx image with Consul Template
 #
-FROM nginx:1.13
+FROM nginx:1.12
 MAINTAINER 1science Devops Team <devops@1science.org>
 
 RUN apt-get update && apt-get install -y curl unzip less vim
 
 # Consul template for configuration management
-ENV S6_OVERLAY_VERSION=1.19.1.1 CONSUL_TEMPLATE_VERSION=0.18.2
+ENV S6_OVERLAY_VERSION=1.21.0.3 CONSUL_TEMPLATE_VERSION=0.19.3
 
 # Install S6 Overlay and Consul Template
 RUN curl -Ls https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-amd64.tar.gz | tar -xz -C /

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -1,7 +1,7 @@
 #
 # Nginx image with Consul Template, based on Alpine Linux
 #
-FROM nginx:1.11-alpine
+FROM nginx:1.13-alpine
 MAINTAINER 1science Devops Team <devops@1science.org>
 
 RUN apk update && apk upgrade && \

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -1,14 +1,14 @@
 #
 # Nginx image with Consul Template, based on Alpine Linux
 #
-FROM nginx:1.13-alpine
+FROM nginx:1.12-alpine
 MAINTAINER 1science Devops Team <devops@1science.org>
 
 RUN apk update && apk upgrade && \
     apk add curl wget bash tree unzip less vim
 
 # Consul template for configuration management
-ENV S6_OVERLAY_VERSION=1.19.1.1 CONSUL_TEMPLATE_VERSION=0.18.2
+ENV S6_OVERLAY_VERSION=1.21.0.3 CONSUL_TEMPLATE_VERSION=0.19.3
 
 # Install S6 Overlay and Consul Template
 RUN curl -Ls https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-amd64.tar.gz | tar -xz -C /

--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ Each branch give the related image tag.
 
 # License
 
-All the code contained in this repository, unless explicitly stated, is
-licensed under ISC license.
+All the code contained in this repository, unless explicitly stated, is licensed under ISC license.
 
 A copy of the license can be found inside the [LICENSE](LICENSE) file.


### PR DESCRIPTION
This PR contains the update Dockerfile for the current stbale NGINX (1.12), to go in parallel with the mainline/latest (1.13). This also includes the updated for S6-overlay and consul-template.

_Note for maintainers_: This is **not** the correct target branch, since I cannot create a `1.12` nor a `stable` branch. Could you please create such a branch (from 1.11 for instance) and update this PR to correctly target either `stable` or `1.12`? (having the `docker-nignx:stable` tag would be really nice)
